### PR TITLE
Add testChannel to config and cancel orders

### DIFF
--- a/config/slack_config.py
+++ b/config/slack_config.py
@@ -4,15 +4,20 @@ from config.config_parser import TacoTuesdayConfigParser
 class TacoTuesdaySlackConfig(TacoTuesdayConfigParser):
     DebugChannel: str = None
     BotToken: str = None
+    TestChannel: str = None
 
     def __init__(self):
         config = TacoTuesdayConfigParser.Yaml['slack']
 
         TacoTuesdaySlackConfig.DebugChannel = config['debugChannel']
         TacoTuesdaySlackConfig.BotToken = config['botToken']
+        TacoTuesdaySlackConfig.TestChannel = config['testChannel']
 
     def get_debug_channel(self):
         return self.DebugChannel
 
     def get_bot_token(self):
         return self.BotToken
+
+    def get_test_channel(self):
+        return self.TestChannel

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -4,6 +4,7 @@ api:
 slack:
   botToken: 'slack-bot-token-goes-here'                                                 
   debugChannel: 'debug-channel'
+  testChannel: 'test-channel-name'
 order:
   taxRate: 8.25                                                                                                     
   maxSingleTaco: 25

--- a/lib/domain/full_order.py
+++ b/lib/domain/full_order.py
@@ -16,6 +16,10 @@ class FullOrder(Order):
     def has_employee_order(self, slack_id: str):
         return slack_id in self.individual_orders
 
+    def is_empty(self):
+        logger.debug(f'Checking if I am empty... Individual Orders: {self.individual_orders}, len: {len(self.individual_orders)}')
+        return len(self.individual_orders) == 0
+
     def add_order(self, order: IndividualOrder):
         [self.add(t, order[t])for t in order.tacos]
 

--- a/lib/proc/handler/action.py
+++ b/lib/proc/handler/action.py
@@ -1,5 +1,6 @@
 from loguru import logger
 
+from config.slack_config import TacoTuesdaySlackConfig
 from lib.proc.handler.base import BaseHandler
 from lib.proc.handler.employee import EmployeeHandler
 from lib.proc.handler.feedback import FeedbackHandler
@@ -37,8 +38,8 @@ class ActionHandler(BaseHandler):
 
     @staticmethod
     def _handle_button_action(action_id, channel_id, slack_id, trigger_id):
-
-        if not ReadyButton.is_ready_button_action(action_id): return
+        if not ReadyButton.is_ready_button_action(action_id):
+            return
 
         if OrderReadyButton.is_order_button_action_id(action_id):
             if RunningOrderHandler.number_of_orders() == 0:

--- a/lib/slack/block/section.py
+++ b/lib/slack/block/section.py
@@ -4,7 +4,7 @@ from lib.slack.text.text import Text
 
 
 class SectionBlock(Block):
-    def __init__(self, text: str, accessory: Accessory = None, fields = None):
+    def __init__(self, text: str, accessory: Accessory = None, fields=None):
         super().__init__('section')
         self.text = Text.get(text, markdown_enabled=True)
         self.accessory = accessory

--- a/lib/slack_impl/message/cancelled_order.py
+++ b/lib/slack_impl/message/cancelled_order.py
@@ -1,0 +1,14 @@
+from lib.slack.block.divider import Divider
+from lib.slack.block.section import SectionBlock
+
+
+class CancelledOrderMessage:
+    def __init__(self):
+        self.blocks = [
+            Divider().get(),
+            SectionBlock(text=':taco::gun: Order Cancelled.').get_block(),
+            Divider().get()
+        ]
+
+    def get_blocks(self):
+        return self.blocks

--- a/lib/slack_impl/message/completed_order.py
+++ b/lib/slack_impl/message/completed_order.py
@@ -1,5 +1,6 @@
 from lib.domain.full_order import FullOrder
 from lib.slack.block.divider import Divider
+from lib.slack.block.section import SectionBlock
 from lib.slack.text.text import Text
 from lib.slack_impl.message.running_order import RunningOrderMessage
 
@@ -10,10 +11,7 @@ class CompletedOrderMessage:
 
     @staticmethod
     def _get_header_section():
-        return {
-            'type': 'section',
-            'text': Text.get(':taco: *Completed Order* :taco:', markdown_enabled=True)
-        }
+        return SectionBlock(text=':taco: *Completed Order* :taco:').get_block()
 
     def get_message(self):
         message = self.running_message.get_message()


### PR DESCRIPTION
This PR adds the `testChannel` property to the YAML config and cancels a `RunningOrder` when the only participant cancels their individual one.